### PR TITLE
Roster size caps + INACTIVE-on-sign; close out Phase 2; gate Phase 3 on Coach model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,9 @@ gametime/
 │   ├── decisions.md           Architecture decision log
 │   ├── risks.md               Active risks and concerns
 │   ├── todo.md                Tactical task list
-│   └── player.md              Player domain design (attributes, skills, formulas)
+│   ├── player.md              Player domain design (attributes, skills, formulas)
+│   ├── roster.md              Roster & lineup domain (player↔team, lineups)
+│   └── coach.md               Coach domain design (attributes — not yet built)
 ├── gametime-service/          Multi-module Maven project (Spring Boot 3.5.14)
 │   ├── pom.xml                Parent POM (packaging=pom)
 │   ├── gametime-api/          OpenAPI codegen module (generates server stubs)
@@ -30,6 +32,7 @@ Before starting work, review these for context:
 - **`docs/roadmap.md`** — phased roadmap, what's built vs what's needed
 - **`docs/roster.md`** — roster & lineup domain: player↔team link, lineups, transactions
 - **`docs/player.md`** — player domain reference: attributes, derived skills, calculator design
+- **`docs/coach.md`** — coach domain design: attribute model + engine interface (pre-Phase-3)
 - **`docs/decisions.md`** — past architecture choices (check before proposing alternatives)
 - **`docs/todo.md`** — current task list
 - **`docs/risks.md`** — known risks and concerns

--- a/docs/coach.md
+++ b/docs/coach.md
@@ -1,0 +1,105 @@
+# Coach Domain *(design — not yet built)*
+
+The Coach is a team's **decision-maker model**: the inputs the game engine reads
+to decide how a team plays — pace, shot distribution, defensive posture, and how
+deep/early the bench gets used.
+
+Today `CoachEntity` is **name-only** (`firstName`, `lastName`, `id`, `team`).
+This doc resolves **Design Decision #3** (continuous vs. categorical) and defines
+the attribute set + the engine-facing interface, so Phase 3 (§3.4 coaching
+effects, §3.5 rotation/substitution) has something concrete to build against.
+
+> **Scope discipline** (cf. decisions.md #014): build the *attribute model* now;
+> the *coaching effects* (how an attribute bends a possession) land with the
+> engine that consumes them. We define the interface, not the formulas, ahead of
+> a consumer that doesn't exist yet.
+
+---
+
+## Decision #3 — continuous, not categorical *(proposed)*
+
+**Recommendation: continuous 1–20 attributes, average = 10 — the same scale as
+player attributes.**
+
+Why continuous over an enum of styles:
+
+- **Consistency.** Players already use 1–20/avg-10 ([player.md](player.md)). One
+  scale across the domain means the engine combines coach and player numbers
+  without translation, and the skill-calculator deviation helper is reusable.
+- **Blending.** A coach who is *somewhat* up-tempo is "pace 13," not forced into
+  a `FAST | BALANCED | SLOW` bucket. The engine can scale effects smoothly.
+- **Progression-friendly.** Phase 6 coach development can nudge a number;
+  promoting/regressing across enum buckets is lumpier.
+- **Seed-friendly.** 40 coaches can be seeded by sampling around 10, exactly like
+  players — no hand-authoring of style categories.
+
+Trade-off: enums read more intuitively ("this is a defensive coach"). Mitigated
+by deriving a **display archetype** from the numbers (e.g. high pace + high
+three-point lean → "modern offense") for UI, without the model itself being
+categorical. Rejected the enum approach as the primary model for the lumpiness
+and translation cost above.
+
+---
+
+## Proposed attributes (1–20, avg 10)
+
+Each attribute exists **because a named Phase 3 consumer needs it** — no
+attribute without a consumer (the #014 discipline). Six to start:
+
+| Attribute | Drives | Consumed by |
+|-----------|--------|-------------|
+| **pace** | Possessions per game / shot-clock urgency | §3.2 possession flow |
+| **offensiveScheme** | Shot distribution — perimeter/3pt lean vs. inside/post | §3.4 shot distribution |
+| **defensiveScheme** | Aggressiveness — pressure/steal-seeking vs. contain | §3.4 defensive scheme |
+| **rotationDepth** | How many players see real minutes (tight 7 vs. deep 10) | §3.5 minutes allocation |
+| **substitutionAggressiveness** | How early/eagerly fatigued starters are pulled | §3.5 sub triggers |
+| **playerDevelopment** | Off-court: rate players improve under this coach | Phase 6 progression |
+
+Deliberately deferred until a consumer is real: in-game adjustments, timeout
+usage, matchup/iso targeting, clutch-time tweaks. Add them when §3.x asks.
+
+---
+
+## Engine-facing interface
+
+The engine reads coach attributes; it never writes them. Effects are **modifiers
+on a baseline**, not absolute values — a coach bends what the players would do,
+they don't override it. Concretely (formulas TBD with the engine):
+
+```
+basePace        × f(pace)                 → team possessions
+baseShotMix     × f(offensiveScheme)      → perimeter vs. interior shot share
+baseStealRate   × f(defensiveScheme)      → pressure vs. foul/breakdown risk
+rotationOrder   + f(rotationDepth)        → who plays, how many minutes  (input: #014)
+fatigueThreshold× f(substitutionAggr.)    → when a sub fires             (§3.5)
+```
+
+`rotationOrder` (the bench depth chart, already shipped in #014) is the roster's
+contribution; `rotationDepth` / `substitutionAggressiveness` are how the coach
+*uses* that chart. That's the clean seam between the roster domain and gameplay.
+
+---
+
+## Implementation outline *(when this task starts)*
+
+1. **Decide #3** — confirm continuous; record in decisions.md.
+2. **Attributes** — finalize the set above (add/cut with consumer justification).
+3. **Schema** — Liquibase changeset adds the columns to `coach`; H2-compatible
+   defaults + Postgres triggers per the audit-column convention.
+4. **Entity** — add fields to `CoachEntity` (Lombok `@Data`).
+5. **Seed** — extend `coach.csv` (40 rows) with sampled-around-10 values.
+6. **Mapping** — wire through `EntityMapper`; expose on the coach in API models if
+   `GET /team` should surface them.
+7. **Tests** — entity + mapping coverage (JaCoCo gate).
+
+No engine code. The effects (`f(...)` above) are Phase 3.
+
+---
+
+## Open questions
+
+- **Derived archetype for display** — compute on read, or store? (Lean: compute.)
+- **Does the API expose coach attributes**, or are they engine-internal until
+  there's a UI consumer? (Lean: internal until Phase 7 needs them.)
+- **GM attributes** — same name-only gap exists for GM, but its consumers
+  (Phase 6.4 trades/draft) are further off; resolve GM separately, later.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -100,6 +100,13 @@ Roster membership ("on a team or not") stays **derived from `player_team`** (no 
 **Trade-off**: `GET /team` and `GET /league` now hydrate lineup fields for every player even when a caller only wanted names; trivial at 40 teams, and a lean projection can be added later if it ever matters. `PUT /lineup` and `DELETE /{playerId}` are unchanged (they are actions, not redundant reads).  
 **Alternatives considered**: Keep both as summary vs. detail tiers (rejected — two endpoints to keep coherent, no real consumer for the split); fold team context into `/roster` instead (rejected — `Team` is the more fundamental resource).
 
+### 016 — Roster size caps; signed players default to `INACTIVE`
+**Date**: 2026-06  
+**Decision**: A team's roster is capped at **15 active** (every `lineupRole` except `MINORS`) + **5 minors**. Signing a free agent (`POST /v1/team/{teamId}/{playerId}`) now defaults the new `player_team.lineupRole` to **`INACTIVE`** ("on the active roster, not yet slotted") and rejects with **409** when the active roster is already full. The lineup PUT also re-checks both caps over the *resulting* roster (request overlaid on current, omitted players keep their role) and rejects with **400** if active > 15 or minors > 5. Caps live as constants `MAX_ACTIVE_ROSTER` / `MAX_MINORS` in `GametimeServiceImp`.  
+**Rationale**: The sign endpoint had no role to set, leaving a just-signed player in a fourth, null-bucket state that size limits couldn't count. Defaulting to `INACTIVE` (chosen over a new `RESERVE` value or splitting `lineupRole` into a separate `rosterStatus` field) eliminates the null without reversing #013/#014's single-field model. The seed data made this safe with no migration: all 422 `roster.csv` rows already carry a bucket (zero nulls), `INACTIVE` was referenced nowhere but the enum decl, and every seeded team is 9–12 players — under the 15 cap, so no grandfathering. The active cap is enforced at *both* sign and lineup PUT so role shuffles can't grow the active roster past what signing allows.  
+**Trade-off**: `INACTIVE` now carries a slight double meaning — "just signed, unslotted" and the eventual in-game "dressed but not playing"; acceptable since the latter has no consumer yet. Position min/max is still unbuilt (deferred to the lineup PUT where the full assignment is visible).  
+**Alternatives considered**: Add a dedicated `RESERVE` lineupRole (rejected — extra enum value for a state `INACTIVE` already covers); split `lineupRole` into membership-tier + in-game-slot fields (rejected — partially reverses #013/#014 and still needs a sign-time default); treat null as a first-class "unassigned" state (rejected — pushes null-handling into every count + the engine).
+
 ---
 
 *Template for new entries:*

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -107,6 +107,13 @@ Roster membership ("on a team or not") stays **derived from `player_team`** (no 
 **Trade-off**: `INACTIVE` now carries a slight double meaning — "just signed, unslotted" and the eventual in-game "dressed but not playing"; acceptable since the latter has no consumer yet. Position min/max is still unbuilt (deferred to the lineup PUT where the full assignment is visible).  
 **Alternatives considered**: Add a dedicated `RESERVE` lineupRole (rejected — extra enum value for a state `INACTIVE` already covers); split `lineupRole` into membership-tier + in-game-slot fields (rejected — partially reverses #013/#014 and still needs a sign-time default); treat null as a first-class "unassigned" state (rejected — pushes null-handling into every count + the engine).
 
+### 017 — No position min/max roster rules (won't build)
+**Date**: 2026-06  
+**Decision**: Roster construction is **not** constrained by player position. There are no per-position (or position-group) minimums or maximums on a roster or lineup. A team may carry any positional mix it likes.  
+**Rationale**: Two reasons. (1) The seed data can't support minimums — no team carries all 9 positions (each has 6–8 of 9), and CG/WING are thin league-wide, so any per-position floor would invalidate most seeded rosters on day one (same trap avoided in #016). (2) Maximums solve a problem the game engine should own: a lopsided roster (e.g. 10 centers) is naturally punished by losing — poor guard play, no spacing — rather than by an API validation rule. Pre-empting that with a roster-layer cap fabricates a constraint ahead of any consumer, against the "let the engine decide" principle (cf. #014 deferring rotationOrder to the engine).  
+**Trade-off**: A user *can* build a nonsensical roster. Accepted — it's their loss in simulation, and it keeps the roster API free of balance rules that belong in gameplay.  
+**Revisit if**: the game engine ships and playtesting shows unconstrained rosters produce degenerate or unfun results that the simulation alone doesn't correct — then position rules become an engine-informed feature, not a guessed-at one.
+
 ---
 
 *Template for new entries:*

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -14,7 +14,7 @@ Active risks and concerns. Remove items as they're resolved (move to the Resolve
 ### Coach/GM attribute design is undefined
 **Severity**: Medium  
 **Description**: Coaches and GMs are currently name-only entities. The game engine needs coach attributes to influence gameplay (pace, defensive scheme, rotation depth), but the attribute model hasn't been designed yet. This is a dependency for Phase 3.  
-**Mitigation**: Resolve in Phase 1.2/1.3 before starting game engine work.
+**Mitigation**: Now the explicit **pre-Phase-3 task** (roadmap.md "Pre-Phase-3 — Coach model"; todo.md "Next"). Resolve open Design Decision #3 (continuous vs. categorical) and define the engine-facing attribute interface before starting game engine work.
 
 ### Skill formula balance
 **Severity**: Medium  

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,22 +32,34 @@ Basketball simulation game — 40-team league with attribute-driven gameplay, se
 
 ---
 
-## Phase 2 — Roster & Lineup Management (CURRENT)
+## Phase 2 — Roster & Lineup Management — COMPLETE (2026-06-28)
 
 **Goal**: Turn the static player list into a managed roster with lineup logic.
-The roster/lineup API surface is built (see "Fully Built"); the remaining work
-is roster rules and rotation depth. Tactical breakdown lives in
-[todo.md](todo.md).
+**Done** — roster/lineup API surface, roster rules, and the lineup depth chart
+are all shipped. Tactical detail in [todo.md](todo.md).
 
-### 2.2 Roster Rules
-- [ ] Roster size limits (e.g., 15 active, 5 minors)
-- [ ] Position minimums/maximums per roster
-- [ ] Roster validation on add/remove
+### 2.2 Roster Rules — DONE
+- [x] Roster size limits — 15 active, 5 minors (#016)
+- [x] Roster validation on add — `INACTIVE` default + active cap (#016)
+- [~] Position minimums/maximums — **decided against** (#017); roster construction
+      is unconstrained by position (a lopsided roster is punished by the engine).
 
-### 2.3 Lineup & Rotation depth (feeds the engine)
-- [ ] Bench rotation order and minutes allocation
-- [ ] Fatigue model: how does `endurance` interact with minutes played?
-- [ ] Coach attributes influence rotation depth (gated on Coach model — deferred)
+> **Lineup & rotation depth (former §2.3) moved to §3.5.** Minutes allocation,
+> fatigue, and coach rotation influence are gameplay ("produced by games being
+> played"), not roster content. The roster-domain input they need — the
+> `rotationOrder` bench depth chart — already shipped in 2.1 (#014).
+
+---
+
+## Pre-Phase-3 — Coach model (CURRENT)
+
+**Goal**: Settle the Coach attribute model before the engine consumes it.
+`CoachEntity` is name-only; the engine (§3.4/§3.5) needs defined coach attributes
+to drive pace, shot distribution, defensive scheme, and rotation style.
+
+- [ ] Resolve **Design Decision #3**: continuous (1–10) vs. categorical styles
+- [ ] Define the coach attribute set + the interface the engine reads
+- [ ] Implement the attribute model only; coaching *effects* land with the engine
 
 ---
 
@@ -79,11 +91,14 @@ is roster rules and rotation depth. Tactical breakdown lives in
 - [ ] Rebalance skill calculator formulas once possessions exercise them
       (clutch/foulProne/transition etc. only get tested under real play)
 
-### 3.5 Fatigue & Substitution
-- [ ] Per-player energy tracking within a game
+### 3.5 Minutes, Fatigue & Substitution
+*(absorbs the former §2.3 — gameplay, not roster. Input: `rotationOrder` depth
+chart from 2.1/#014.)*
+- [ ] Minutes allocation: bench `rotationOrder` → distribution of playing time
+- [ ] Per-player energy tracking within a game (`endurance` ↔ minutes played)
 - [ ] Skill degradation as energy drops
 - [ ] Automatic substitution triggers based on fatigue thresholds
-- [ ] Coach rotation style determines when subs happen
+- [ ] Coach rotation style determines when subs happen (gated on Coach model)
 
 ### 3.6 Simulation APIs
 - [ ] `POST /v1/game/simulate` — simulate a single game, return box score
@@ -246,7 +261,7 @@ These are open questions that should be resolved before or during implementation
 The phases above are roughly sequential, but here's the critical path:
 
 ```
-[Foundation ✓] ──> Phase 2 (Rosters) ──> Phase 3 (Game Engine) ──> Phase 4 (Stats)
+[Foundation ✓] ──> Phase 2 (Rosters) ✓ ──> Coach model ──> Phase 3 (Game Engine) ──> Phase 4 (Stats)
                                                         │
                                                         v
                                                 Phase 5 (Season) ──> Phase 6 (Progression)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ Basketball simulation game — 40-team league with attribute-driven gameplay, se
   roster assignment — see decisions.md #013.
 - **40-team league** across 4 conferences (EAST, NORTH, SOUTH, WEST), 422 seed players (CSV-driven via Liquibase)
 - **Entity layer**: Player, Team, Coach (name only), GM (name only); player↔team decoupled via `player_team` + `player_team_hist`
-- **Roster & lineup model**: a team's roster is part of the `Team` resource (`players` are roster entries with lineup slot); lineup (starting 5 + bench rotation order) is sticky state on `player_team`; player status (availability) is separate from lineup role. See decisions.md #013–#015.
+- **Roster & lineup model**: a team's roster is part of the `Team` resource (`players` are roster entries with lineup slot); lineup (starting 5 + bench rotation order) is sticky state on `player_team`; player status (availability) is separate from lineup role; roster size caps (15 active / 5 minors) enforced on sign + lineup, signed players default to `INACTIVE`. See decisions.md #013–#017.
 - **REST endpoints**: GET league, GET player by ID + history, createPlayer, updatePlayer; GET team by ID (incl. roster), addPlayerToTeam, removePlayerFromTeam, set lineup
 - **Skill calculation engine**: SkillCalculator interface, 23 calculator implementations, SkillMapper orchestrator
 - **Entity-to-model mapping**: EntityMapper with full attribute + skill wiring

--- a/docs/roster.md
+++ b/docs/roster.md
@@ -114,16 +114,14 @@ Size caps (`MAX_ACTIVE_ROSTER = 15`, `MAX_MINORS = 5` in `GametimeServiceImp`):
   on the lineup PUT (400) so role shuffles can't grow it past the sign limit.
 - **Minors cap (5)** = count of `MINORS`. A sign never lands in `MINORS`, so this
   is purely a lineup-PUT invariant (400).
-- **Position min/max** — not yet built; will live in the lineup PUT where the
-  full assignment is visible. See decisions.md #016.
+- **Position** — intentionally unconstrained: there are no position minimums or
+  maximums. A team may carry any positional mix; a lopsided roster is punished by
+  the game engine, not an API rule. See decisions.md #017.
 
 ## Not yet built
 
 These touch the roster domain but are not implemented yet:
 
-- **Position min/max per roster** — the remaining roster rule; will be enforced
-  on the lineup PUT (size caps + the `INACTIVE`-on-sign default are done — see
-  the "Roster rules" section above and decisions.md #016).
 - **Minutes & fatigue** (Phase 3.5) — `rotationOrder` + `endurance` drive minutes
   allocation and in-game substitution.
 - **Coach rotation influence** (Phase 3.5) — gated on the Coach model (parked).

--- a/docs/roster.md
+++ b/docs/roster.md
@@ -54,8 +54,10 @@ Two independent axes, with no shared values (decisions.md #013):
 ## Assignment & release
 
 A player is added to a team with `POST /v1/team/{teamId}/{playerId}`: it inserts
-the `player_team` row and appends a `SIGN` record to `player_team_hist`. It is
-404 if the team or player is missing, 409 if the player is already on a team.
+the `player_team` row (with `lineupRole = INACTIVE` — on the active roster, not
+yet slotted) and appends a `SIGN` record to `player_team_hist`. It is 404 if the
+team or player is missing, and **409** if the player is already on a team **or
+the active roster is full** (see Roster rules below).
 
 `DELETE /v1/team/{teamId}/{playerId}` releases a player to free agency: it
 removes the `player_team` row and appends a `RELEASE` record to
@@ -100,13 +102,28 @@ rotationOrder}`. It is valid when:
 - Every `playerId` belongs to `{teamId}` (else 404).
 - No player appears twice.
 - `rotationOrder` is unique among all non-null values.
+- The resulting roster (request overlaid on current; omitted players keep their
+  role) has **≤ 15 active** (non-`MINORS`) and **≤ 5 `MINORS`** (else 400).
+
+## Roster rules
+
+Size caps (`MAX_ACTIVE_ROSTER = 15`, `MAX_MINORS = 5` in `GametimeServiceImp`):
+
+- **Active cap (15)** = count of every `lineupRole` except `MINORS`. Enforced on
+  sign (409) — a signed player lands `INACTIVE`, which is active — and re-checked
+  on the lineup PUT (400) so role shuffles can't grow it past the sign limit.
+- **Minors cap (5)** = count of `MINORS`. A sign never lands in `MINORS`, so this
+  is purely a lineup-PUT invariant (400).
+- **Position min/max** — not yet built; will live in the lineup PUT where the
+  full assignment is visible. See decisions.md #016.
 
 ## Not yet built
 
 These touch the roster domain but are not implemented yet:
 
-- **Roster rules** — size limits (e.g. 15 active, 5 minors), position
-  minimums/maximums, enforced on add and lineup operations.
+- **Position min/max per roster** — the remaining roster rule; will be enforced
+  on the lineup PUT (size caps + the `INACTIVE`-on-sign default are done — see
+  the "Roster rules" section above and decisions.md #016).
 - **Minutes & fatigue** (Phase 3.5) — `rotationOrder` + `endurance` drive minutes
   allocation and in-game substitution.
 - **Coach rotation influence** (Phase 3.5) — gated on the Coach model (parked).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -32,9 +32,12 @@ Decisions locked 2026-06-27: lineup lives on `player_team` (not a new join
 table); lineup PUT is replace-all with a hard 5-starter invariant.
 
 ### 2.2 Roster rules (next)
-- [ ] Roster size limits (e.g. 15 active, 5 minors).
-- [ ] Position minimums/maximums per roster.
-- [ ] Roster validation on add (currently only "not already on a team").
+- [x] Roster size limits — 15 active (everything but MINORS), 5 minors. Active cap
+      enforced on sign (`POST /{playerId}` → 409) and on lineup PUT; minors cap
+      enforced on lineup PUT (→ 400). (#016)
+- [x] Roster validation on add — sign now defaults `lineupRole = INACTIVE` and
+      checks the active-roster cap (was: only "not already on a team"). (#016)
+- [ ] Position minimums/maximums per roster (lineup PUT — full assignment visible).
 
 ### 2.3 Lineup & rotation depth (feeds the engine)
 - [ ] Bench rotation order → minutes allocation.
@@ -51,3 +54,14 @@ Loose tactical chores with no phase home (deferred scope lives in
 - [ ] Hand-tune marquee/star players to 18–20 where appropriate (the rescale was
       mechanical). Deferred until the game engine shows whether it matters.
 - [ ] Evaluate Testcontainers as an alternative to H2 for integration tests.
+- [ ] Separate test seed data from production seed. Today both the `local`
+      (Postgres) and test (H2) profiles load the *same* Liquibase changelog
+      (`db/changelog.yml` → `players.csv`, `roster.csv`, `release.1.0.1.dataload.sql`),
+      so tests assert against production seed rows. Runtime league changes (trades,
+      new signings) only touch Postgres and don't affect tests, but *editing the seed
+      files* can break tests that hardcode team IDs / sizes. Introduce a small fixed
+      test-only fixture (e.g. `test/resources/db/` changelog the test profile points
+      at) so `main/resources/db/` can evolve for production independently. Interim
+      mitigation done: roster-rule tests in `RosterLineupDelegateTest` now sign their
+      own players instead of assuming seed roster sizes; remaining brittleness is the
+      hardcoded team IDs themselves.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,12 +5,12 @@ them as completed. For the big-picture phased roadmap and what's already
 shipped, see [roadmap.md](roadmap.md). Deferred work lives in the
 Backlog at the bottom.
 
-Current focus: **Phase 2 roster APIs shipped — next up: roster rules + rotation
-depth (roadmap.md §2.2/§2.3).**
+Current focus: **Phase 2 (Rosters & Lineups) COMPLETE. Before gameplay: revisit
+the Coach model (open Design Decision #3). Then Phase 3 — Game Engine.**
 
 ---
 
-## Phase 2 — Rosters & Lineups
+## Phase 2 — Rosters & Lineups — COMPLETE (2026-06-28)
 
 ### 2.1 Roster APIs — DONE (2026-06-27)
 
@@ -31,7 +31,7 @@ Three endpoints on top of the existing player↔team model, plus the lineup
 Decisions locked 2026-06-27: lineup lives on `player_team` (not a new join
 table); lineup PUT is replace-all with a hard 5-starter invariant.
 
-### 2.2 Roster rules (next)
+### 2.2 Roster rules — DONE (2026-06-28)
 - [x] Roster size limits — 15 active (everything but MINORS), 5 minors. Active cap
       enforced on sign (`POST /{playerId}` → 409) and on lineup PUT; minors cap
       enforced on lineup PUT (→ 400). (#016)
@@ -42,10 +42,21 @@ table); lineup PUT is replace-all with a hard 5-starter invariant.
       lopsided roster (e.g. 10 centers) is best punished by the game engine, not an
       API rule. Roster construction stays unconstrained by position.
 
-### 2.3 Lineup & rotation depth (feeds the engine)
-- [ ] Bench rotation order → minutes allocation.
-- [ ] Fatigue model: how `endurance` interacts with minutes played.
-- [ ] Coach attributes influence rotation depth (gated on Coach model — backlog).
+> The old §2.3 (minutes allocation, fatigue, coach rotation influence) was **not
+> roster content** — it's "produced by games being played" (gameplay), per the
+> domain boundary in roster.md. It has moved to **roadmap.md §3.5**. Its one
+> roster-domain input — the `rotationOrder` bench depth chart — already shipped
+> in 2.1 (#014).
+
+## Next — before Phase 3 (gameplay)
+
+### Coach model — revisit (gates the game engine)
+- [ ] Resolve **Design Decision #3**: coach attributes as continuous (1–10 like
+      players) vs. categorical styles (enum). `CoachEntity` is name-only today.
+- [ ] Define the coach attribute set + the interface the engine reads (pace, shot
+      distribution, defensive scheme, rotation style — consumed by §3.4/§3.5).
+- [ ] Implement only the attribute model now; the *coaching effects* land with the
+      engine that consumes them (avoid designing formulas in a vacuum — cf. #014).
 
 ---
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,57 +5,27 @@ them as completed. For the big-picture phased roadmap and what's already
 shipped, see [roadmap.md](roadmap.md). Deferred work lives in the
 Backlog at the bottom.
 
-Current focus: **Phase 2 (Rosters & Lineups) COMPLETE. Before gameplay: revisit
-the Coach model (open Design Decision #3). Then Phase 3 — Game Engine.**
+Current focus: **Coach model** — the pre-gameplay prerequisite. Phase 2
+(Rosters & Lineups) is complete; its record lives in [roadmap.md](roadmap.md)
+§2 and decisions.md #013–#017.
 
 ---
 
-## Phase 2 — Rosters & Lineups — COMPLETE (2026-06-28)
+## Coach model (CURRENT — gates the game engine)
 
-### 2.1 Roster APIs — DONE (2026-06-27)
+`CoachEntity` is name-only; Phase 3 (§3.4/§3.5) can't be built against it.
+Design work goes in [coach.md](coach.md); this is the task checklist.
 
-Three endpoints on top of the existing player↔team model, plus the lineup
-(starting 5 + rotation order) concept the game engine needs.
-
-- [x] Team roster with lineup slots — folded into `GET /v1/team/{teamId}`
-      (`Team.players` are `RosterEntry`); standalone `/roster` removed (#015).
-- [x] `PUT /v1/team/{teamId}/lineup` — replace-all `LineupRequest`; hard 400 on
-      ≠5 STARTER, starter-with-order, dup player, or dup rotation order; 404 if a
-      player isn't on the team. Returns the updated Team.
-- [x] `DELETE /v1/team/{teamId}/{playerId}` — release to free agency: drop the
-      `player_team` row, append a `RELEASE` row to `player_team_hist`. 200/404.
-- [x] Schema: `release.1.0.4.lineup.sql` adds `lineup_role` + `rotation_order`
-      to `player_team`. Entity, service, delegate, `EntityMapper.toRosterEntry`,
-      `.http` samples all wired. 12 delegate tests; JaCoCo gate green.
-
-Decisions locked 2026-06-27: lineup lives on `player_team` (not a new join
-table); lineup PUT is replace-all with a hard 5-starter invariant.
-
-### 2.2 Roster rules — DONE (2026-06-28)
-- [x] Roster size limits — 15 active (everything but MINORS), 5 minors. Active cap
-      enforced on sign (`POST /{playerId}` → 409) and on lineup PUT; minors cap
-      enforced on lineup PUT (→ 400). (#016)
-- [x] Roster validation on add — sign now defaults `lineupRole = INACTIVE` and
-      checks the active-roster cap (was: only "not already on a team"). (#016)
-- [~] Position minimums/maximums per roster — **decided against** (#017). No seed
-      team carries all 9 positions, so minimums would invalidate the league; and a
-      lopsided roster (e.g. 10 centers) is best punished by the game engine, not an
-      API rule. Roster construction stays unconstrained by position.
-
-> The old §2.3 (minutes allocation, fatigue, coach rotation influence) was **not
-> roster content** — it's "produced by games being played" (gameplay), per the
-> domain boundary in roster.md. It has moved to **roadmap.md §3.5**. Its one
-> roster-domain input — the `rotationOrder` bench depth chart — already shipped
-> in 2.1 (#014).
-
-## Next — before Phase 3 (gameplay)
-
-### Coach model — revisit (gates the game engine)
 - [ ] Resolve **Design Decision #3**: coach attributes as continuous (1–10 like
-      players) vs. categorical styles (enum). `CoachEntity` is name-only today.
-- [ ] Define the coach attribute set + the interface the engine reads (pace, shot
+      players) vs. categorical styles (enum). Write the decision into decisions.md.
+- [ ] Define the coach attribute set + the engine-facing interface (pace, shot
       distribution, defensive scheme, rotation style — consumed by §3.4/§3.5).
-- [ ] Implement only the attribute model now; the *coaching effects* land with the
+- [ ] Schema + entity: add the attributes to `CoachEntity` / `coach` table
+      (Liquibase changeset), seed values into `coach.csv`.
+- [ ] Map attributes through `EntityMapper`; expose on the coach in `GET /team`
+      if the API should surface them.
+- [ ] Tests for the new mapping/entity (JaCoCo gate).
+- [ ] Implement the attribute *model* only — coaching *effects* land with the
       engine that consumes them (avoid designing formulas in a vacuum — cf. #014).
 
 ---

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -37,7 +37,10 @@ table); lineup PUT is replace-all with a hard 5-starter invariant.
       enforced on lineup PUT (→ 400). (#016)
 - [x] Roster validation on add — sign now defaults `lineupRole = INACTIVE` and
       checks the active-roster cap (was: only "not already on a team"). (#016)
-- [ ] Position minimums/maximums per roster (lineup PUT — full assignment visible).
+- [~] Position minimums/maximums per roster — **decided against** (#017). No seed
+      team carries all 9 positions, so minimums would invalidate the league; and a
+      lopsided roster (e.g. 10 centers) is best punished by the game engine, not an
+      API rule. Roster construction stays unconstrained by position.
 
 ### 2.3 Lineup & rotation depth (feeds the engine)
 - [ ] Bench rotation order → minutes allocation.

--- a/gametime-service/gametime-app/src/main/java/software/daveturner/gametime/service/GametimeServiceImp.java
+++ b/gametime-service/gametime-app/src/main/java/software/daveturner/gametime/service/GametimeServiceImp.java
@@ -23,9 +23,15 @@ public class GametimeServiceImp implements GametimeService {
 
     private final EntityMapper entityMapper;
 
+    /** Max players on the active roster (everything except MINORS). */
+    static final int MAX_ACTIVE_ROSTER = 15;
+    /** Max players in the minors. */
+    static final int MAX_MINORS = 5;
+
     Comparator<Team> byConfById
             = Comparator.comparing(Team::getConference)
             .thenComparing(t -> t.getId().toString());
+
     public GametimeServiceImp(TeamRepo teamRepo, PlayerRepo playerRepo,
                               PlayerTeamRepo playerTeamRepo, PlayerTeamHistRepo playerTeamHistRepo,
                               EntityMapper entityMapper) {
@@ -87,6 +93,15 @@ public class GametimeServiceImp implements GametimeService {
         if (playerTeamRepo.existsById(playerId)) {
             throw new ResourceConflictException("Player already on a team");
         }
+        // A signed free agent lands on the active roster (INACTIVE = on roster,
+        // not yet in the playing rotation), so the active-roster cap applies.
+        long active = playerTeamRepo.findByTeamId(teamId).stream()
+                .filter(pt -> pt.getLineupRole() != software.daveturner.gametime.entity.LineupRole.MINORS)
+                .count();
+        if (active >= MAX_ACTIVE_ROSTER) {
+            throw new ResourceConflictException(
+                    "Active roster is full (max " + MAX_ACTIVE_ROSTER + ")");
+        }
         assign(playerId, teamId, TransactionType.SIGN);
     }
 
@@ -113,6 +128,12 @@ public class GametimeServiceImp implements GametimeService {
         Map<String, PlayerTeamEntity> current = playerTeamRepo.findByTeamId(teamId).stream()
                 .collect(Collectors.toMap(PlayerTeamEntity::getPlayerId, pt -> pt));
 
+        // Resulting role per roster player: start from current, override with the
+        // request. Players omitted from the request keep their existing role, so the
+        // size caps below reflect the full post-update roster, not just the request.
+        Map<String, software.daveturner.gametime.entity.LineupRole> resultingRoles = new HashMap<>();
+        current.forEach((pid, pt) -> resultingRoles.put(pid, pt.getLineupRole()));
+
         Set<String> seen = new HashSet<>();
         Set<Integer> rotationOrders = new HashSet<>();
         int starters = 0;
@@ -128,6 +149,7 @@ public class GametimeServiceImp implements GametimeService {
                 throw new ResourceBadRequestException("Missing lineup role");
             }
             software.daveturner.gametime.entity.LineupRole role = toEntityRole(e.getLineupRole());
+            resultingRoles.put(playerId, role);
             if (role == software.daveturner.gametime.entity.LineupRole.STARTER) {
                 starters++;
                 // starters are an unordered set of 5 — they carry no rotation order
@@ -143,6 +165,21 @@ public class GametimeServiceImp implements GametimeService {
         }
         if (starters != 5) {
             throw new ResourceBadRequestException("Lineup must have exactly 5 starters");
+        }
+
+        // Size caps over the resulting roster — also enforced here so role shuffles
+        // can't grow the active roster past what the sign endpoint allows.
+        long minors = resultingRoles.values().stream()
+                .filter(r -> r == software.daveturner.gametime.entity.LineupRole.MINORS)
+                .count();
+        long active = resultingRoles.size() - minors;
+        if (active > MAX_ACTIVE_ROSTER) {
+            throw new ResourceBadRequestException(
+                    "Active roster exceeds max " + MAX_ACTIVE_ROSTER);
+        }
+        if (minors > MAX_MINORS) {
+            throw new ResourceBadRequestException(
+                    "Minors exceeds max " + MAX_MINORS);
         }
 
         // all valid — apply
@@ -186,6 +223,9 @@ public class GametimeServiceImp implements GametimeService {
         current.setTeamId(teamId);
         current.setTransactionType(type);
         current.setAssignedDate(now);
+        // Default bucket: on the active roster, not yet slotted into the lineup.
+        // Set the lineup PUT to promote into STARTER/ROTATION/BENCH or demote to MINORS.
+        current.setLineupRole(software.daveturner.gametime.entity.LineupRole.INACTIVE);
         playerTeamRepo.save(current);
 
         PlayerTeamHistEntity hist = new PlayerTeamHistEntity();

--- a/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/api/RosterLineupDelegateTest.java
+++ b/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/api/RosterLineupDelegateTest.java
@@ -147,6 +147,15 @@ class RosterLineupDelegateTest {
                 () -> api.setLineup("BOS", new LineupRequest().entries(List.of())));
     }
 
+    @Test
+    void ensureSetLineupThrowsBadRequestWhenEntryHasNoRole() {
+        List<String> players = rosterPlayerIds("LA");
+        LineupRequest req = validLineup(players);
+        // an entry with no lineup role is rejected
+        req.getEntries().get(0).setLineupRole(null);
+        assertThrows(ResourceBadRequestException.class, () -> api.setLineup("LA", req));
+    }
+
     // ---- removePlayerFromTeam ----
 
     @Test
@@ -180,6 +189,124 @@ class RosterLineupDelegateTest {
         // assignment exists, but for LA not SF
         assertThrows(ResourceNotFoundException.class,
                 () -> api.removePlayerFromTeam("SF", created.getId()));
+    }
+
+    // ---- roster rules: default role on sign + size caps ----
+
+    @Test
+    void ensureSignedPlayerDefaultsToInactiveLineupRole() {
+        Player created = api.createPlayer(freshPlayer()).getBody();
+        api.addPlayerToTeam("BUF", created.getId());
+        try {
+            LineupRole role = api.fetchTeam("BUF").getBody().getPlayers().stream()
+                    .filter(e -> e.getPlayer().getId().equals(created.getId()))
+                    .findFirst().orElseThrow().getLineupRole();
+            assertEquals(LineupRole.INACTIVE, role);
+        } finally {
+            api.removePlayerFromTeam("BUF", created.getId());
+        }
+    }
+
+    @Test
+    void ensureSignThrowsConflictWhenActiveRosterFull() {
+        // NY ships with the smallest seed roster; fill its active roster to the cap.
+        String teamId = "NY";
+        int existingActive = (int) api.fetchTeam(teamId).getBody().getPlayers().stream()
+                .filter(e -> e.getLineupRole() != LineupRole.MINORS)
+                .count();
+        List<String> signed = new ArrayList<>();
+        try {
+            for (int i = existingActive; i < 15; i++) {
+                Player p = api.createPlayer(freshPlayer()).getBody();
+                api.addPlayerToTeam(teamId, p.getId());
+                signed.add(p.getId());
+            }
+            // roster now at the 15-active cap — the next sign must 409
+            Player overflow = api.createPlayer(freshPlayer()).getBody();
+            signed.add(overflow.getId()); // created but should not get assigned
+            assertThrows(ResourceConflictException.class,
+                    () -> api.addPlayerToTeam(teamId, overflow.getId()));
+        } finally {
+            for (String id : signed) {
+                try { api.removePlayerFromTeam(teamId, id); } catch (RuntimeException ignored) { }
+            }
+        }
+    }
+
+    @Test
+    void ensureSetLineupThrowsBadRequestWhenMinorsExceedsCap() {
+        // Exceeding the minors cap (5) needs 5 starters + at least 6 more players, i.e.
+        // an >=11-player roster. Rather than assume a seed team is that big, sign enough
+        // fresh players to guarantee it, so the test survives any seed roster size.
+        String teamId = "HOU";
+        List<String> signed = new ArrayList<>();
+        try {
+            while (rosterPlayerIds(teamId).size() < 11) {
+                Player p = api.createPlayer(freshPlayer()).getBody();
+                api.addPlayerToTeam(teamId, p.getId());
+                signed.add(p.getId());
+            }
+            List<String> players = rosterPlayerIds(teamId);
+            LineupRequest req = validLineup(players); // first 5 STARTER, rest BENCH
+            // mark 6 of the non-starters MINORS (no rotation order) -> 6 > cap of 5
+            int minorsMarked = 0;
+            for (int i = 5; i < req.getEntries().size() && minorsMarked < 6; i++) {
+                req.getEntries().get(i).setLineupRole(LineupRole.MINORS);
+                req.getEntries().get(i).setRotationOrder(null);
+                minorsMarked++;
+            }
+            assertEquals(6, minorsMarked);
+            assertThrows(ResourceBadRequestException.class, () -> api.setLineup(teamId, req));
+        } finally {
+            for (String id : signed) {
+                try { api.removePlayerFromTeam(teamId, id); } catch (RuntimeException ignored) { }
+            }
+        }
+    }
+
+    @Test
+    void ensureSetLineupThrowsBadRequestWhenActiveExceedsCap() {
+        // VAN (11 seed players, untouched by other tests) — build a 16-player roster
+        // (15 active + 1 minors) and try to promote everyone to active via the PUT.
+        // A 16th active sign is impossible (the sign cap blocks it), so the only way to
+        // a 16-player roster is to park one in MINORS via the PUT, then sign the 16th.
+        // Only the signed players are released afterward; the seed roster is left intact.
+        String teamId = "VAN";
+        List<String> signed = new ArrayList<>();
+        try {
+            // 1. fill to the 15-active cap (VAN seeds 11 active -> sign 4)
+            int active = (int) api.fetchTeam(teamId).getBody().getPlayers().stream()
+                    .filter(e -> e.getLineupRole() != LineupRole.MINORS).count();
+            for (int i = active; i < 15; i++) {
+                Player p = api.createPlayer(freshPlayer()).getBody();
+                api.addPlayerToTeam(teamId, p.getId());
+                signed.add(p.getId());
+            }
+            // 2. PUT a valid lineup that parks a *signed* player in MINORS -> 14 active,
+            //    1 minors (park a signed one so seed roles are restored on release).
+            //    Order the parked player last so validLineup makes it bench, not a
+            //    starter — then override it to MINORS without breaking the 5-starter rule.
+            String parkId = signed.get(signed.size() - 1);
+            List<String> ordered = new ArrayList<>(rosterPlayerIds(teamId));
+            ordered.remove(parkId);
+            ordered.add(parkId); // parkId is now last -> bench in validLineup
+            LineupRequest park = validLineup(ordered);
+            park.getEntries().get(park.getEntries().size() - 1)
+                    .lineupRole(LineupRole.MINORS).rotationOrder(null);
+            assertEquals(200, api.setLineup(teamId, park).getStatusCode().value());
+            // 3. room opened (14 active) — sign the 16th player (active 14 -> 15)
+            Player p16 = api.createPlayer(freshPlayer()).getBody();
+            api.addPlayerToTeam(teamId, p16.getId());
+            signed.add(p16.getId());
+            // 4. now 16 on the roster; a lineup making all 16 active -> 16 > 15 -> 400
+            LineupRequest overfill = validLineup(rosterPlayerIds(teamId));
+            assertThrows(ResourceBadRequestException.class,
+                    () -> api.setLineup(teamId, overfill));
+        } finally {
+            for (String id : signed) {
+                try { api.removePlayerFromTeam(teamId, id); } catch (RuntimeException ignored) { }
+            }
+        }
     }
 
     private Player freshPlayer() {


### PR DESCRIPTION
## Summary

Completes Phase 2 (Rosters & Lineups): adds the remaining roster rules, then
closes the phase out and sets up the Coach model as the pre-gameplay prerequisite.

### Roster rules (code) — `61ba517`, `abaacbd`
- **Default role on sign** — `assign()` sets `lineupRole = INACTIVE` (on the
  active roster, not yet slotted), eliminating the prior null-bucket state for a
  freshly signed free agent.
- **Size caps** (decision #016): active cap (15, everything but `MINORS`)
  enforced on sign (409) **and** re-checked on the lineup PUT (400) so role
  shuffles can't bypass the sign limit; minors cap (5) enforced on the lineup
  PUT (400).
- **Position min/max — decided against** (decision #017): no seed team carries
  all 9 positions (so minimums would invalidate the league), and a lopsided
  roster is best punished by the game engine, not an API rule.

### Tests
- New coverage for the default role, both caps' throw branches, and the
  null-role lineup branch. `GametimeServiceImp` at 98% line / 85% branch;
  JaCoCo gate green. Cap tests sign their own players rather than assuming seed
  roster sizes, so they survive seed changes.

### Roadmap / domain docs — `9b42086`, `62a218d`
- **Phase 2 marked complete.** The former §2.3 (minutes allocation, fatigue,
  coach rotation influence) is reclassified as **gameplay, not roster** (per the
  domain boundary in `roster.md`) and moved to roadmap §3.5; its one
  roster-domain input — the `rotationOrder` depth chart — already shipped (#014).
- **Coach model is now the explicit pre-Phase-3 gate.** `CoachEntity` is
  name-only and the engine (§3.4/§3.5) can't be built against it.
- **New `docs/coach.md`** — design proposal resolving Design Decision #3
  (recommends continuous 1–20 attributes like players over a style enum),
  proposing a six-attribute set each tied to a named Phase 3 consumer, and
  defining the engine-facing interface. *Proposal awaiting review — no coach
  code in this PR.*
- `todo.md` refocused on the Coach model; roster size caps noted in roadmap
  "Fully Built"; `coach.md` + `roster.md` registered in the CLAUDE.md docs index.

## Test plan
- [x] `JAVA_HOME=...21 mvn clean install` — all tests pass, "All coverage checks have been met."

🤖 Generated with [Claude Code](https://claude.com/claude-code)