### PR TITLE
test(sim): §3.19 instrumentation — make the harness and seeded tests …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ gametime/
 │   ├── decisions.md           Architecture decision log
 │   ├── risks.md               Active risks and concerns
 │   ├── todo.md                Tactical task list (current phase only — CURRENTLY:
-│   │                          §3.19 INSTRUMENTATION, execute-ready)
+│   │                          §3.20 RECALIBRATION, needs a DESIGN PASS)
 │   ├── backlog.md             Homeless infra/tooling chores (cross-phase)
 │   ├── ideas.md               Parking lot — untriaged future-improvement ideas
 │   ├── calibration.md         Calibration targets — THE source of truth for them
@@ -120,12 +120,11 @@ When adding or changing production code under `gametime-app/src/main/java`,
 invoke the **`test-coverage`** skill — the JaCoCo gate is per-package and runs at
 `install`, not `test`, so a green `mvn test` does not prove it passes.
 
-⚠ **Until §3.19 lands, a green `mvn clean install` does NOT prove CI will pass.**
-`V1ApiDelegateimplTest` is not `@Transactional` and commits roster rows, which shifts the
-sim's RNG consumption downstream — so sim tests can pass in the full suite and fail in
-isolation. **§3.19 fixes this** (see todo.md); **delete this note when it does.**
-Meanwhile, after any change touching `PossessionEngine`/`ShotSelector`/`RotationState`,
-also run the sim classes alone:
+✅ **§3.19 closed the full-suite-vs-isolation gap** — `V1ApiDelegateimplTest` used to
+commit roster rows, shifting the sim's RNG consumption downstream, so sim tests could
+pass in the full suite and fail alone. It is `@Transactional` now. **Still cheap and
+still worth doing** after any change touching `PossessionEngine`/`ShotSelector`/
+`RotationState` — run the sim classes alone:
 ```
 JAVA_HOME=... mvn -pl gametime-app -f gametime-service/pom.xml test -Dtest='GameSimulatorIntegrationTest' -DfailIfNoTests=false
 ```

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -420,49 +420,6 @@ planned features), see [ideas.md](ideas.md).
       this chore too, and running them together means one person holds both halves of that
       contract. **Behavior-neutral by definition: no test should change.**
 
-- [ ] **Harness self-verification — assert the instrument's own invariants.**
-      ⚠ **PROMOTED TO A §3.19 PREREQUISITE ("Step 0") — user call, 2026-08.** Do NOT pick this up as a standalone chore: it must be resolved **in §3.19's design pass, before any tuning**, because §3.19 tunes against the very instrument this entry says is unreliable. See roadmap.md's §3.19 bullet.
-      ⚠ **PARTIALLY DONE by §3.15 (#035 A/F): the load-bearing half below — "have the
-      harness print the constants it actually ran with" — is BUILT.** The report now
-      names the active profile list and dumps every tunable constant's effective value.
-      It has already earned its place: it caught §3.15's own harness bug, where a
-      hardcoded `POSSESSIONS_PER_PERIOD = 25` shadowed the profile's pace key, which is
-      exactly misfire (1) below in a new guise. **What remains open:** the FT-source
-      counts summing to total FTs with no `UNKNOWN`, and points reconciling with the
-      event log. The original text follows.
-      The
-      known risk is that `CalibrationHarness` *reports* and doesn't gate
-      ([risks.md](risks.md)); this is the narrower, cheaper problem underneath it: **the
-      harness can confidently print a wrong baseline**, and nothing catches that. §3.11
-      hit it twice in one session:
-      (1) a `-DandOneBaseOverride=0` flag was passed to disable the new feature for a
-      baseline run — `AND_ONE_BASE` is a compile-time constant, so the flag was silently
-      ignored and three "baseline" runs measured the *shipped* config;
-      (2) the assumption that a zero base disables a rare event turned out false — a
-      zeroed `AND_ONE_BASE` still produced ~0.44 and-1s/team/game, because
-      `rareEventProbability`'s skill term alone stays positive off an even contest
-      (now recorded in `#029`'s implementation note and guarded by a unit test).
-      Both were caught only because the numbers looked *odd* — a recalibration steered
-      off either would have been silently wrong, and the §3.x cadence tunes each phase
-      against the previous phase's baseline.
-      **The pattern to generalize** is already proven in-tree: §3.11's FT-source split
-      carries an `UNKNOWN` bucket, so an untagged free throw shows up as a visible row
-      instead of being mis-attributed to a real source. Do the same for the harness's own
-      assumptions — assert, per batch, that the FT-source counts **sum to** total FTs with
-      no `UNKNOWN`; that points reconcile with the event log; and above all that a
-      **"baseline" run's config is the config it claims** — have the harness *print the
-      constants it actually ran with*, so a run is self-describing the way an event is.
-      That last one is the load-bearing fix: it catches misfire (1) directly, and it is
-      the honest form of the check, because misfire (2) proved that "feature off" is
-      **not** the same as "base = 0" for a rare event (only the caller's gate truly
-      disables one). A run that prints `AND_ONE_BASE = 0.11` when the operator believed
-      they had zeroed it is immediately visible; asserting "zero events" would instead
-      have baked in the very assumption that turned out false. Cheap, and it would have
-      caught both §3.11 misfires.
-      *Distinct from the risks.md tolerance-band gate* — that one asks "are the aggregates
-      still on target"; this asks "is the harness measuring what it says it is." The
-      tolerance-band gate is reconsidered at §3.12's close-out; this is worth doing
-      **before** §3.12's recalibration, since that pass steers off a 115.9 baseline.
 - [ ] **Clear the 5 open Dependabot alerts — all in `gametime-frontend`, none in the
       Maven service.** *(Surfaced 2026-08 on a `git push`; GitHub reports them against
       the default branch. Filed here rather than in a phase: it is dependency hygiene,
@@ -557,59 +514,10 @@ planned features), see [ideas.md](ideas.md).
       **Not §3.17's** (blocks are a §3.19 row, #038's rule) — but §3.19 must not re-tune
       the four `base-block-*` without holding this, or it will tune a constant that does
       nothing and conclude the lever is dead.
-      ⚠ **PROMOTED TO A §3.19 PREREQUISITE ("Step 0") — user call, 2026-08.** Do NOT pick this up as a standalone chore: it must be resolved **in §3.19's design pass, before any tuning**, because §3.19 tunes against the very instrument this entry says is unreliable. See roadmap.md's §3.19 bullet.
-
-- [ ] **A test asserts a ~13% RANDOM EVENT on a pinned seed, and it is ALSO order-dependent
-      — so a green local `mvn install` does not prove it passes.** Found 2026-08 when CI
-      failed on §3.17's branch after two clean local full builds.
-      ⚠ **PROMOTED TO A §3.19 PREREQUISITE ("Step 0") — user call, 2026-08.** Do NOT pick this up as a standalone chore: it must be resolved **in §3.19's design pass, before any tuning**, because §3.19 tunes against the very instrument this entry says is unreliable. See roadmap.md's §3.19 bullet.
-      ⚠ §3.19 moves the RNG stream more than any pass since §3.17, so **re-pinning the
-      seed a third time is the default outcome unless this is fixed first.**
-      `GameSimulatorIntegrationTest.technicalFoulsArePersistedOnTheBoxScoreAndReconcileWithTheEvents`
-      opens with a **precondition** — *"a 40-possession game must produce at least one
-      technical"* — that keeps its reconciliation from passing vacuously. ⚠ **That is not
-      an invariant.** The per-check technical probability is **~0.00175**, so 40
-      possessions × 2 teams expects **~0.14** technicals: "at least one" fires on roughly
-      **one seed in eight**. It has now broken **twice** on passes that touched neither
-      technicals nor fouls — §3.14b (flagrant roll consumed an extra draw, seed 7 → 9) and
-      §3.17 (the shot mix changed `pickShotType`'s result on nearly every possession, seed
-      9 → 12). Each time the fix was to re-measure and re-pin, which works and does not
-      scale.
-      ⚠ **THE ORDER-DEPENDENCE IS THE BIGGER HALF, AND IT DEFEATS THE LOCAL GATE.**
-      Measured: the test **fails in isolation and passes in the full suite on the same
-      seed**. `V1ApiDelegateimplTest` is **not** `@Transactional` and commits roster rows;
-      that changes who is on the floor, which changes the RNG consumption pattern
-      downstream. **So the suite passing is the lucky ordering, not the honest result** —
-      exactly how §3.17 shipped a red branch after `mvn clean install` reported
-      `BUILD SUCCESS` twice.
-      ⚠ **THIS ENTRY CONFLATES THREE THINGS — separate them before choosing a fix**
-      *(clarified 2026-08 by a user question: "is this really just about the test case?").*
-      **(1)** the precondition is a **coin flip**; **(2)** the fixture is **inflated to win
-      that flip**; **(3)** test *order* changes simulation output. (3) is independent of
-      the other two.
-      ⚠ **On (2) — the parameter is possessions PER PERIOD, not per game.** The baseline is
-      **25** (`sim.default-possessions-per-period`), which is what most sim tests use and
-      what a real game plays. **This test passes 40 — a deliberately inflated ~1.6× game —
-      purely to make a rare event likely enough to assert.**
-      **The durable fix:** ⚠ **NOT "raise the possession count"** — that pushes 40 to 60 or
-      100 and makes the fixture *less* like a real game to win a probability bet, and it
-      needs raising again every time the technical rate moves. **It is not a
-      test-quality fix; it trades one problem for another.**
-      **Instead: assert the reconciliation identity over a BATCH OF SEEDS and drop the
-      precondition entirely.** The identity (`events == box-score column`) is what the test
-      is actually for; it holds at zero technicals too, it just proves nothing there. ⚠ **A
-      batch also lets the test run at the REALISTIC 25** — ten seeds there is
-      non-vacuous by construction, with no seed pinning and no inflated fixture. That is
-      the option that fixes (1) and (2) together. **Also worth fixing independently:**
-      make `V1ApiDelegateimplTest` `@Transactional`, or give the sim tests their own
-      fixture, so test order stops changing simulation output.
-      ✅ **CHECKED 2026-08 — `@Transactional` is the recommendation, and the "is it
-      deliberately non-transactional?" question is ANSWERED NO.** The class carries no
-      `@Transactional`, no `@DirtiesContext`, no ordering annotation and no explanatory
-      comment, across 15 independent test methods — an oversight, not a choice to exercise
-      real commit behavior. ⚠ **The risk when applying it:** a method silently depending on
-      committed state from an earlier one will start failing. That is the fix **surfacing**
-      a latent coupling, not causing it; if it happens, give the sim tests their own
-      fixture instead.
-      ⚠ **Audit for siblings before closing**: any other fixed-seed test whose assertion
-      depends on a rare event firing. Grep for seed literals in `sim` tests.
+      ⚠ **NOT resolved by §3.19 (instrumentation) — that phase was test-side only and
+      deliberately did not reroute `blockProbability`.** The effect was SIZED and closed on
+      that basis: **~half a blocked three per team-game**, on a row already on target, with
+      no consumer for the per-type split. **Carry it as a footnote for §3.20**: if a pass
+      ever tunes `base-block-*`, reroute through `clampRareProbability` FIRST, or that lever
+      reads dead. The broader half — auditing which other tunables sit under the floor —
+      is still open and still homeless.

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -35,8 +35,19 @@ say so.
 ## Everything, in one table
 
 All figures are **per team per game** unless noted. Current = the **5-seed mean, seeds
-1000–5000** (2026-08) on the `baseline` profile. **Target column: sourced rows are
-Basketball-Reference league averages, per game, 2025-26.**
+1000–5000**, re-measured 2026-08 at the end of §3.19 on the `baseline` profile — **this
+is §3.20's input**. §3.19 was test-side only and moved no engine number (proven
+same-seed before/after); the rows that moved against the previous reading were stale, not
+new. **Target column: sourced rows are Basketball-Reference league averages, per game,
+2025-26.**
+
+✅ **The harness now self-verifies three identities, and all three read OK on every one
+of those five seeds** — assists+blocks vs. the box score (pre-existing), **FT sources**
+(the per-source counts sum to total FTs with an empty `UNKNOWN` bucket) and **points**
+(events = box score = final score), both added by §3.19. A number below is therefore not
+lying about *what it counted*; whether the engine should produce it is §3.20's question.
+⚠ **A `MISMATCH(es)` on any of those lines invalidates the rows it feeds — fix the
+instrument before reading anything.**
 
 **Type** — `TARGET` = calibrated, steer by it. `ballpark` = a plausibility range: judge
 against it but **do not calibrate to it**. `observed` = no target, reported for
@@ -62,17 +73,17 @@ visibility.
 | Pace (poss/48) | **TARGET (SOURCED)** | **99.4** | ~100 nominal | ✅ |
 | Steals | observed | **8.4** | **7.72** | 🔴 **−0.68 (10.3 se) — real, not seed noise.** ⚠ **A DERIVED quantity**: steals = turnovers × STOLEN share, and *both* terms are §3.20's (TO 13.90 vs 14.5; share 55.5%, inside the intended 55–60% band). **Fixing TO to 14.5 alone yields 8.05** — re-measure after it lands, do **not** tune the share independently |
 | **Foul-outs** | **TARGET** (soft, **UNSOURCED**) | **~0.39** | **0.304** | ⚠ **A LANDING, not a benchmark** — see *Foul-outs* |
-| Players at 4 / 5 / 6 fouls | ballpark | *(no range yet)* | 1.31 / 0.63 / 0.52 | **the real diagnostic for foul-outs** — judge by this, not the headline count |
-| **Technicals** | ballpark | **~0.3–0.4** (~0.6–0.8 league-wide) | **0.350** | ⚠️ **judge at 5 SEEDS ONLY** — see *Technicals* |
+| Players at 4 / 5 / 6 fouls | ballpark | *(no range yet)* | 0.94 / 0.46 / 0.30 | **the real diagnostic for foul-outs** — judge by this, not the headline count |
+| **Technicals** | ballpark | **~0.3–0.4** (~0.6–0.8 league-wide) | **0.358** | ⚠️ **judge at 5 SEEDS ONLY** — see *Technicals* |
 | **Flagrants** | ballpark (**UNSOURCED**) | **~0.13–0.20** (~0.25–0.40 league-wide) | **0.141** | ⚠️ **the COARSEST row here — 5 SEEDS ONLY.** ⚠ Its divisor is a **measured foul rate**: any pass that moves fouls must re-measure it, or this row silently reads low |
-| Flagrant-2s | *(no target — a 15% share)* | — | **0.035** | the ejection driver |
-| **Ejections** | *(no target — an outcome)* | — | **0.044** | both causes (technicals alone: 0.014) |
-| Fouled-three rate | ballpark | **~2% of 3PA** | **2.93%** *(corrected)* | ✅ scale-free: held across a 1.9× volume change. ⚠ Raw visible tally reads **1.47%** — the corrected figure is the one to judge |
+| Flagrant-2s | *(no target — a 15% share)* | — | **0.023** | the ejection driver |
+| **Ejections** | *(no target — an outcome)* | — | **0.033** | both causes (technicals alone: ~0.00) |
+| Fouled-three rate | ballpark | **~2% of 3PA** | **2.93%** *(corrected)* | ✅ scale-free: held across a 1.9× volume change. ⚠ Raw visible tally reads **1.46%** — the corrected figure is the one to judge |
 | 3-FT trips | ballpark | ~0.3–0.6 *here* | **1.09** *(corrected)* | the **count** tripled with 3PA while the **rate** above held. ⚠ The 0.3–0.6 range was set at half the current 3PA |
-| And-1s | ballpark | ~4–6% of made FG | 1.88 (4.5%) | ✅ |
-| Fouls / team / period | observed | — | 5.15 | bonus at 5 — ⚠️ **AT the threshold**, which is why the penalty rate is volatile |
+| And-1s | ballpark | ~4–6% of made FG | 1.55 (3.9%) | 🟡 just under the band; moves with the shot mix (§3.20's) |
+| Fouls / team / period | observed | — | 4.58 | bonus at 5 — ⚠️ **AT the threshold**, which is why the penalty rate is volatile |
 | Team-periods in penalty | observed | — | 46.1% | ⚠️ **a result, not a knob — but it PRICES the FTA share above** |
-| Out of bounds | observed | — | 2.8 | |
+| Out of bounds | observed | — | 3.1 | |
 | Turnover cause mix | observed | STOLEN dominant | 55.5% | no per-cause target |
 | Period-by-period FG% | observed | flat, not sagging | flat | correct fatigue behavior |
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1286,11 +1286,14 @@ number.
 spread across five entries — a cold session would have to read #036, #039, #040 and #041
 to assemble it. **This block is an INDEX, not a new decision**: each row cites the entry
 that owns it, and that entry stays authoritative. Live values are in `calibration.md`;
-the design questions are in `todo.md`; the phase's Step 0 is in `roadmap.md`.*
+**the design questions are in `roadmap.md`'s §3.20 bullet** — they were parked there
+deliberately so they survive todo.md's per-phase rewrite, which happened at §3.19's
+close-out (2026-08). ⚠ **todo.md holds no §3.20 questions until that pass opens and
+rewrites it.***
 
 **§3.20 is the LAST Phase-3 sub-phase and adds NO mechanic.** Every pass before it
 settled the *shape* — foul mix (§3.16), shot mix (§3.17), event vocabulary (§3.18) — and
-§3.19 re-solves the *numbers* now that the shape is final (#038). ⚠ **If the pass finds
+**§3.20** re-solves the *numbers* now that the shape is final (#038). ⚠ **If the pass finds
 itself adding a branch, it has grown beyond recalibration.**
 
 | Gap | Owner | The constraint that is easy to miss |
@@ -1298,12 +1301,12 @@ itself adding a branch, it has grown beyond recalibration.**
 | **2P% ~48.7 vs sourced 55.0** — the largest | **#040 F** | ⚠ **`base-three` must NOT move** — 3P% is correct and held across a 1.9× volume change. Lever is `base-drive`/`base-post`/`base-perimeter`. The error was always there; §3.17 made it *visible* by fixing the mix that hid it |
 | **Points 110.0 vs 115.6** | **#039 H** | ⚠ **The ~8-point drop was deliberate** — §3.16 removed ~10 FTA on purpose. **Not drift.** #039 H sized the recovery as roughly a 5% pace bump |
 | **FTA 19.76 vs 23.5** | **#039 D**, re-priced by **#040** | ⚠ `sim.non-shooting-foul-share` is **priced by the PENALTY RATE, not the foul rate alone** (46.1%, down from 55.7%). **Tune against the FTA line, never against points.** The share is DERIVED, not sourced |
-| **FGA 92.28 vs 89.1 (OVER)** | **#040 E** | ⚠ §3.17 *spent* FGA headroom knowingly. **#039 C's dead-possession concession is NOT reopened** — that was asked and answered no. §3.19 owns pace |
+| **FGA 92.28 vs 89.1 (OVER)** | **#040 E** | ⚠ §3.17 *spent* FGA headroom knowingly. **#039 C's dead-possession concession is NOT reopened** — that was asked and answered no. **§3.20** owns pace |
 | **Def rebounds 30.48 vs 32.4** | **#040 H** | ⚠ A **rate** question, **not a new sub-phase**. §3.17 closed ~3.0 of the 5.0 gap; the residual is `sim.base-offensive-rebound` and the paths that divert misses from the rebound draw |
-| **Steals 7.72 vs 8.4** | **#041 F** | ⚠ **DERIVED**: steals = turnovers × STOLEN share, and *both* terms are §3.19's. Fixing turnovers to 14.5 alone yields ~8.05. **Re-measure after turnovers land; do not tune the share independently** |
-| **Blocks 4.80 — green for the WRONG reason** | **#040** impl. note | ⚠ **`PROB_FLOOR` (0.02) is 4× `base-block-three` (0.005), so the constant is INERT.** The lever will read as dead. **A Step 0 prerequisite** |
+| **Steals 7.72 vs 8.4** | **#041 F** | ⚠ **DERIVED**: steals = turnovers × STOLEN share, and *both* terms are **§3.20's**. Fixing turnovers to 14.5 alone yields ~8.05. **Re-measure after turnovers land; do not tune the share independently** |
+| **Blocks 4.80 — green for the WRONG reason** | **#040** impl. note | ⚠ **`PROB_FLOOR` (0.02) is 4× `base-block-three` (0.005), so the constant is INERT.** The lever will read as dead. ⚠ **CLOSED, NOT DEFERRED** — §3.19 SIZED it at ~half a blocked three per team-game on a row already on target, with no consumer for the per-type split. **A footnote, not work**: only if this pass tunes `base-block-*`, reroute through `clampRareProbability` first |
 
-**⚠ Three things §3.19 must NOT do**, each already argued and closed:
+**⚠ Three things §3.20 must NOT do**, each already argued and closed:
 - **Do not re-tune §3.13's foul-trouble sit curve** — measured **saturated** (#031).
 - **Do not touch the turnover count, gate or cause weights** — frozen (#027 A).
 - **Do not read a moved number as an engine change without asking which** — *did the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -753,10 +753,40 @@ re-running the loop and re-agreeing the numbers, not a red build.
       reconciliation (`STOLEN` events vs. box-score steals) already works today**. Do the
       cheap measurement first; it may show the rate is fine and this phase is pure parity.
 
-- [ ] **§3.19 — Instrumentation: make the harness and the seeded tests trustworthy
+- [x] **§3.19 — Instrumentation: make the harness and the seeded tests trustworthy
       BEFORE recalibration tunes against them** *(added 2026-08 by user call, splitting
       what had been bolted onto recalibration as a "Step 0"; **recalibration moves to
-      §3.20**)*. ⚠ **Nearly design-free — it is execute-ready and its plan is in
+      §3.20**)*.
+      _Shipped (execution 2026-08, **no `#NNN` — the phase resolved no design question**;
+      all three tasks landed exactly as planned, so there was nothing to diverge from).
+      **The defining property held: it moved NO engine number** — the harness run on seed
+      1000 before and after is identical line for line across all 150 report lines, the
+      only difference being the two new reconciliation lines themselves.
+      **(1)** Two checks joined the existing `Agg.reconciliationMismatches` mechanism as
+      their own named counters, so a failure says WHICH instrument broke:
+      `Reconciliation (ft-src)` (per-source FT counts sum to total `FREE_THROW` events
+      **and** the `UNKNOWN` bucket is empty — a sum-only check would pass with every FT
+      tagged `UNKNOWN`, the exact failure it exists to catch) and
+      `Reconciliation (points)` (2/3 per made SHOT + 1 per made FREE_THROW from the event
+      log **= box-score total = final score**, all three, since `agg.points` is read off
+      the score while every other row is derived from events). Both read **OK on all five
+      seeds**. **(2)** The technicals test now asserts `technicalEvents == boxTechnicals`
+      over **ten seeds** at the realistic **25** possessions/period, with the
+      `assertTrue(technicals > 0)` precondition **deleted** — the identity holds on every
+      seed including zero-technical ones (0 == 0 still proves the persisted column is
+      written), so the batch is non-vacuous **by construction** and there is nothing left
+      to re-pin after three seed re-baselines. An audit of every other fixed-seed sim
+      assertion found **no siblings**: the remaining preconditions ride fouls (~18/game),
+      shooting fouls (~6.5/team/game) and and-1s (~1.6/team/game), none a coin flip.
+      **(3)** `@Transactional` on `V1ApiDelegateimplTest` — **no method failed**, so no
+      latent coupling surfaced and the sim tests kept their shared fixture. Sim classes now
+      green **run alone**, which is what the annotation was for. 576 + 52 tests green,
+      JaCoCo gate met. **Exit condition met**: the 5-seed mean (seeds 1000–5000) is
+      recorded in [calibration.md](calibration.md)'s Current column and is §3.20's input;
+      the rows that moved against the previous reading were **stale, not new** (4/5/6
+      fouls 0.94/0.46/0.30, and-1s 1.55, fouls/period 4.58, OOB 3.1, ejections 0.033).
+      **Delete CLAUDE.md's "until §3.19 lands" warning — it has landed.**_
+      ⚠ **Nearly design-free — it is execute-ready and its plan is in
       [todo.md](todo.md).** The decisions are already made; do not run a design pass for it.
       **Why it is its own phase rather than a preamble:** §3.20 reads **every** number it
       tunes from `CalibrationHarness`, and a wrong reading does not announce itself — it

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -6,122 +6,49 @@ shipped, see [roadmap.md](roadmap.md). Homeless infra/tooling chores live in
 [backlog.md](backlog.md); deferred *gameplay* scope lives in roadmap.md's
 **Possession-fidelity completion** section.
 
-Current focus: **§3.19 — instrumentation**. Phase 3's tail is now
-**§3.18 steals (SHIPPED) → §3.19 instrumentation → §3.20 recalibration**.
+Current focus: **§3.20 — recalibration**, which **needs a DESIGN PASS first**.
+Phase 3's tail is **§3.18 steals (SHIPPED) → §3.19 instrumentation (SHIPPED) → §3.20
+recalibration**.
 ⚠ **RECALIBRATION HAS BEEN RENUMBERED A FOURTH TIME** — it was §3.16, then §3.18, then
 §3.19, and is now **§3.20**. **Read the phase NAME, never the number alone.**
-§3.7–§3.18 have all shipped.
+§3.7–§3.19 have all shipped.
 
-> **✅ §3.19 IS A SMALL EXECUTION PHASE. IT NEEDS NO DESIGN PASS.**
-> **Three test-side tasks, all decided** — the only open detail is a seed count, picked
-> while writing the test. Expect **one sitting**, not a phase's worth of work: two
-> assertions added to an existing harness mechanism, one test rewritten to loop seeds, and
-> one annotation. **Do not run a design session for this**, and do not expand the scope to
-> justify the phase number. Add an implementation note only if something diverges, and
-> flip the roadmap bullet to `[x]`.
+> **§3.20 NEEDS ITS OWN DESIGN SESSION, AND IT OPENS WITH A MEASUREMENT RATHER THAN WITH
+> QUESTIONS.** That measurement is done: **§3.19's 5-seed run (seeds 1000–5000) is
+> recorded in [calibration.md](calibration.md)'s Current column** and is this pass's
+> first input. **This file has NOT been rewritten for §3.20** — that is the design
+> session's first job, and its content lives in **roadmap.md's §3.20 bullet** in the
+> meantime (see the pointer section below).
 >
-> ⚠ **THE REST OF THIS FILE'S CONTEXT IS ABOUT §3.20 (RECALIBRATION) AND IS DELIBERATELY
-> PARKED — DO NOT START IT.** §3.20 is the big pass: it needs **its own design session,
-> which opens with a MEASUREMENT rather than with questions**, and that measurement is
-> **this phase's exit condition.** So the order is:
-> **finish §3.19 → run the 5-seed harness → record the mean → THEN open §3.20's design
-> pass** (in a new session, with this file rewritten for it).
-> ⚠ **Do not bundle them.** §3.19 makes the instruments honest; §3.20 tunes against them.
-> Doing both at once is what this split exists to prevent — and it would put code changes
-> inside a design session, breaking the design→execution rhythm fifteen sub-phases have
-> held. **§3.20's content lives in [roadmap.md](roadmap.md)'s §3.20 bullet**, not here, so
-> it survives this file's rewrite; the thin pointer section at the bottom is intentional.
->
-> **Why it is a phase and not a footnote:** §3.20 reads **every** number it tunes from
-> `CalibrationHarness`, and a wrong reading does not announce itself — it looks like a
-> calibration gap, so you tune a constant to chase a measurement error. §3.11 hit exactly
-> that twice in one session and both were caught only because the numbers looked *odd*.
->
-> ⚠ **ALL THREE TASKS ARE TEST-SIDE AND MUST MOVE NO ENGINE NUMBER.** That is the phase's
-> defining property, exactly as §3.18's was. **Verify it the cheap way: run the harness on
-> one seed, `git stash` the tree, run it again, and diff — it must be identical line for
-> line.** If anything moved, stop and find out why.
+> ✅ **§3.19 (instrumentation) SHIPPED 2026-08 — no `#NNN`, because it resolved no design
+> question.** All three tasks landed as planned, and **the phase moved no engine number**
+> (same-seed harness run before/after, identical line for line). The full landing note is
+> on **roadmap.md's §3.19 bullet**; what §3.20 needs to know from it is short:
+> - **The harness now self-verifies THREE identities**, all reading `OK` on all five
+>   seeds: `ast+blk` (pre-existing), **`ft-src`** (per-source FT counts sum to total FTs
+>   **and** the `UNKNOWN` bucket is empty) and **`points`** (events = box score = final
+>   score). ⚠ **A `MISMATCH(es)` on any of them invalidates the rows it feeds — fix the
+>   instrument before reading a number.** That is the whole point of the phase: a wrong
+>   reading looks like a calibration gap, so you tune a constant to chase a measurement
+>   error.
+> - **The seeded tests are trustworthy now.** The technicals test asserts its identity
+>   over ten seeds at the realistic 25 possessions/period with the coin-flip precondition
+>   deleted, so **no §3.20 change can break it by shifting the RNG stream**. And
+>   `V1ApiDelegateimplTest` is `@Transactional`, so **a green `mvn clean install` finally
+>   does mean the sim tests pass in isolation** — run them alone anyway, it is cheap.
+> - **Some calibration.md rows moved against the previous reading. They were STALE, not
+>   new** (4/5/6 fouls 0.94/0.46/0.30, and-1s 1.55, fouls/period 4.58, OOB 3.1, ejections
+>   0.033). ⚠ Do not read them as drift and do not tune toward the old values.
 
 ---
 
-## §3.19 execution plan
+## §3.20 (recalibration) — the NEXT phase. Pointers only, until its design pass rewrites this file.
 
-**Build preamble.** Java 21 or Lombok breaks:
-`JAVA_HOME=/Users/dave/.sdkman/candidates/java/21.0.9-tem`. The **JaCoCo gate is
-per-package and runs at `install`, not `test`** — invoke the `test-coverage` skill.
-Invoke `project-docs` before touching any doc. ⚠ **A green `mvn clean install` does not
-prove CI will pass** — run the sim classes **alone** too (CLAUDE.md); task 3 exists
-precisely because of that.
-
-**Task 1 — finish harness self-verification**
-- [ ] The harness already self-checks two things — `Reconciliation (ast+blk)`, per game
-      across all 102 (`CalibrationHarness`, the `Agg.reconciliationMismatches` counter).
-      **Extend that same mechanism; do not build a parallel one.**
-- [ ] **FT-source counts must sum to total FTs, with zero `UNKNOWN`.** Sources are read
-      off an outcome suffix (`MADE_SHOOTING`, `MISSED_BONUS`, …), so an untagged or
-      mis-tagged outcome lands in `UNKNOWN` and **silently distorts the FT-source
-      percentages §3.20 reads.** Nothing asserts that bucket is empty today.
-- [ ] **Points must reconcile with the event log** — sum 2/3 per made FG and 1 per made
-      FT from the events and check it against the box-score total. **Points is a headline
-      §3.20 target and nothing currently verifies the harness computes it consistently.**
-- [ ] Report the result on the existing reconciliation line (or beside it), in the same
-      `OK` / `N MISMATCH(es)` form.
-
-**Task 2 — fix the brittle technicals test**
-- [ ] `GameSimulatorIntegrationTest.technicalFoulsArePersistedOnTheBoxScoreAndReconcile...`
-      asserts a **~13% random event** on a pinned seed (`assertTrue(technicals > 0)`), and
-      has broken **twice** on passes that touched neither technicals nor fouls.
-- [ ] **Assert `technicalEvents == boxTechnicals` over a batch of ~10 seeds and DELETE the
-      precondition.** The identity holds for **every** seed — including zero-technical
-      ones — so a batch is non-vacuous by construction with nothing to re-pin.
-- [ ] **Drop the fixture to the realistic 25 possessions/period** (the baseline) from
-      today's inflated 40. ⚠ The parameter is possessions **per period**, not per game.
-- [ ] ⚠ **Rejected alternatives, do not revisit:** *raising the possession count* only
-      makes the coin flip a better bet while pushing the fixture further from a real game;
-      *re-pinning the seed* has already failed three times.
-- [ ] ⚠ **Audit for siblings**: any other fixed-seed sim test whose assertion depends on a
-      rare event firing. Grep for seed literals.
-
-**Task 3 — `@Transactional` on `V1ApiDelegateimplTest`**
-- [ ] It is not `@Transactional` and **commits roster rows**, changing who is on the floor
-      and therefore RNG consumption downstream — so **a green local `mvn clean install`
-      does NOT prove CI passes.** That is how §3.17 shipped a red branch after two clean
-      local builds.
-- [ ] ✅ **The "is it deliberately non-transactional?" question was CHECKED (2026-08):
-      no.** No `@Transactional`, no `@DirtiesContext`, no ordering annotation, no
-      explanatory comment, across 15 independent methods — an oversight.
-- [ ] ⚠ **Watch for**: a method silently depending on committed state from an earlier one
-      will start failing. That is the fix **surfacing** a latent coupling, not causing it.
-      If it happens, give the sim tests their own fixture instead.
-
-**Definition of done**
-- `mvn clean install` green (JaCoCo gate included), **and** the sim classes green run
-  **alone** — which task 3 should now make equivalent.
-- ⚠ **Proven to move no engine number** — same-seed harness run before/after, identical.
-- **A clean 5-seed harness run**, profile from the **environment**
-  (`SPRING_PROFILES_ACTIVE=local,baseline`, confirm the `Profiles:` line). ⚠ **Record the
-  mean in `calibration.md`'s Current column — it is §3.20's input.**
-- Roadmap §3.19 bullet flipped to `[x]`; an implementation note on a new `#042` **only if
-  something diverged** (this phase resolves no design questions).
-- ⚠ **Do NOT commit** — leave the work in the tree and wait (CLAUDE.md).
-
-**⚠ Do NOT** *(reference)*
-- **Do NOT tune anything.** No `SimConfig` change, no constant, no rate. This phase makes
-  instruments honest; **§3.20 does the tuning.**
-- **Do NOT reroute `blockProbability`** — closed as not worth it (~half a blocked three
-  per team-game on an on-target row). Footnote only, in the §3.20 bullet.
-- **Do NOT start §3.20's design pass here** — it opens with a measurement, and that
-  measurement is this phase's exit condition.
-
----
-
-## §3.20 (recalibration) — NOT THIS PHASE. Pointers only.
-
-⚠ **Do not start any of this until §3.19 above is done and the 5-seed harness run is
-recorded.** That run is §3.19's exit condition and §3.20's first input.
+✅ **The precondition is met: §3.19 has shipped and its 5-seed run is recorded** in
+[calibration.md](calibration.md)'s Current column. That run is §3.20's first input.
 ⚠ **This section is deliberately thin, and that is not an omission.** The content lives
 in **roadmap.md's §3.20 bullet** so it survives this file's rewrite — todo.md is
-current-phase-only, and it gets rewritten for §3.20 when that pass opens.
+current-phase-only, and **rewriting it for §3.20 is that design pass's first job**.
 
 **When you get there, read in this order:**
 1. **[roadmap.md](roadmap.md)'s §3.20 bullet** — the core problem (**2P%, FTA and points

--- a/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/api/V1ApiDelegateimplTest.java
+++ b/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/api/V1ApiDelegateimplTest.java
@@ -3,13 +3,32 @@ package software.daveturner.gametime.api;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.boot.test.context.*;
+import org.springframework.transaction.annotation.Transactional;
 import software.daveturner.gametime.exception.*;
 import software.daveturner.gametime.model.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 
+/**
+ * §3.19: {@code @Transactional} so each method rolls back, matching every other
+ * {@code @SpringBootTest} in the suite.
+ *
+ * <p><b>Why it is load-bearing rather than tidiness.</b> Without it these methods
+ * COMMIT roster rows (players created and assigned to teams), which changes who is on
+ * the floor in the sim tests that run afterwards — and therefore how the seeded RNG
+ * stream is consumed downstream. The visible symptom was a sim test that
+ * <b>passed in the full suite and failed in isolation on the same seed</b>, which is
+ * how §3.17 shipped a red branch after two clean local {@code mvn install} runs: a
+ * green full-suite build did not prove CI would pass.
+ *
+ * <p>The "is it deliberately non-transactional?" question was checked (2026-08):
+ * <b>no</b> — no {@code @Transactional}, no {@code @DirtiesContext}, no ordering
+ * annotation and no explanatory comment across 15 independent methods. It was an
+ * oversight, and each method is self-contained.
+ */
 @SpringBootTest
+@Transactional
 class V1ApiDelegateimplTest {
 
     // seed player already assigned to a team (team ATL)

--- a/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/sim/CalibrationHarness.java
+++ b/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/sim/CalibrationHarness.java
@@ -213,6 +213,54 @@ class CalibrationHarness {
             agg.reconciliationMismatches++;
         }
 
+        // §3.19: FT-SOURCE reconciliation. The per-source FT split (#029 D) is read
+        // off an outcome SUFFIX, so an untagged or mis-tagged free throw lands in the
+        // UNKNOWN bucket and silently distorts the FT-source percentages §3.20 reads.
+        // Nothing asserted that bucket was empty. The check is the same shape as the
+        // two above — events are the source of truth — with two conditions: the
+        // per-source counts must SUM to the total FREE_THROW events, and the UNKNOWN
+        // bucket must be empty. A sum-only check would pass with every FT tagged
+        // UNKNOWN, which is precisely the failure it exists to catch.
+        long freeThrowEvents = 0;
+        long taggedFreeThrows = 0;
+        long unknownFreeThrows = 0;
+        for (GameEventEntity e : events) {
+            if (e.getPlayType() != PlayType.FREE_THROW) continue;
+            freeThrowEvents++;
+            if ("UNKNOWN".equals(freeThrowSource(e.getOutcome()))) {
+                unknownFreeThrows++;
+            } else {
+                taggedFreeThrows++;
+            }
+        }
+        if (unknownFreeThrows > 0 || taggedFreeThrows != freeThrowEvents) {
+            agg.freeThrowSourceMismatches++;
+        }
+
+        // §3.19: POINTS reconciliation. Points is a headline §3.20 target and nothing
+        // verified the harness computed it consistently — agg.points comes off the
+        // final SCORE, while every other row is derived from the event log. Sum 2/3
+        // per made SHOT and 1 per made FREE_THROW from the events and check that
+        // against both the box-score total and the final score. All three must agree:
+        // if they ever diverge, a target row is being read off a different quantity
+        // than the play-by-play describes.
+        long eventPoints = 0;
+        for (GameEventEntity e : events) {
+            String outcome = e.getOutcome();
+            if (outcome == null || !outcome.startsWith("MADE")) continue;
+            if (e.getPlayType() == PlayType.SHOT) {
+                eventPoints += ShotType.THREE.name().equals(shotTypeSuffix(outcome))
+                        ? ShotType.THREE.getPoints() : 2;
+            } else if (e.getPlayType() == PlayType.FREE_THROW) {
+                eventPoints++;
+            }
+        }
+        int boxPoints = boxScores.stream().mapToInt(b -> nz(b.getPoints())).sum();
+        int finalScore = result.getHomeScore() + result.getAwayScore();
+        if (eventPoints != boxPoints || boxPoints != finalScore) {
+            agg.pointsMismatches++;
+        }
+
         // §3.8 (decisions.md #026 D): count OUT_OF_BOUNDS_* REBOUND events so the OOB
         // rate is VISIBLE (no hard target) — sail-out is a genuinely new outcome that
         // removes a rebound chance, so its rate must be watchable to confirm the
@@ -545,6 +593,13 @@ class CalibrationHarness {
         long fga, fgm, tpa, tpm, assists, turnovers, offReb, defReb, blocks, steals, oob;
         long periods;
         int reconciliationMismatches;
+        // §3.19: the two checks that finish the harness's self-verification. Kept as
+        // their OWN counters rather than folded into the line above so a failure names
+        // WHICH instrument broke — the whole point is that a wrong reading does not
+        // announce itself, and "1 MISMATCH(es)" on a shared counter would not say
+        // whether the FT tags or the points arithmetic drifted.
+        int freeThrowSourceMismatches;
+        int pointsMismatches;
 
         // §3.5 per-slot minutes (slot 0 = biggest-minutes player per team-game).
         final long[] minutesBySlot = new long[MAX_TRACKED_SLOTS];
@@ -699,6 +754,16 @@ class CalibrationHarness {
             lines.add(String.format("Reconciliation (ast+blk):%s",
                     reconciliationMismatches == 0 ? " OK (all games match)"
                             : " " + reconciliationMismatches + " MISMATCH(es)"));
+            // §3.19: the two self-checks added to finish the mechanism. Same
+            // OK / N MISMATCH(es) form, one line each so the failing instrument is
+            // named. FT sources feed the per-source split below; points is a headline
+            // §3.20 target read off the score rather than off the event log.
+            lines.add(String.format("Reconciliation (ft-src):%s",
+                    freeThrowSourceMismatches == 0 ? " OK (all FTs tagged, no UNKNOWN)"
+                            : " " + freeThrowSourceMismatches + " MISMATCH(es)"));
+            lines.add(String.format("Reconciliation (points): %s",
+                    pointsMismatches == 0 ? "OK (events = box score = final)"
+                            : pointsMismatches + " MISMATCH(es)"));
 
             System.out.println();
             System.out.println("======== §3.4 + §3.5 + §3.7 CALIBRATION REPORT =========");

--- a/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/sim/GameSimulatorIntegrationTest.java
+++ b/gametime-service/gametime-app/src/test/java/software/daveturner/gametime/sim/GameSimulatorIntegrationTest.java
@@ -460,61 +460,69 @@ class GameSimulatorIntegrationTest {
      * <p>This is the assertion that catches the sim → entity write being dropped: the
      * field is nullable and every other layer would still compile and pass without it.
      *
-     * <p><b>§3.14b re-baselined the SEED, 7 → 9; §3.17 re-baselined it again, 9 → 12.</b>
-     * The {@code > 0} line below is a <b>precondition</b> that keeps the reconciliation
-     * from passing vacuously, not an invariant about technicals. §3.14b's flagrant roll
-     * consumed an extra draw per foul; §3.17 changed what {@code pickShotType} returns on
-     * nearly every possession (#040), and either shifts the whole downstream stream. Each
-     * re-baseline picked the new seed by <b>measuring</b> which seeds still yield
-     * technicals here, never by weakening the assertion to {@code >= 0}. Seed 12 yields
-     * <b>four</b>, the widest margin in the first 60 seeds.
+     * <p><b>§3.19 REBUILT THIS TEST, and the shape is the durable fix the previous
+     * version's own javadoc asked for.</b> It used to simulate ONE pinned seed at an
+     * inflated 40 possessions/period and open with {@code assertTrue(technicals > 0)}
+     * as a precondition against a vacuous pass. That precondition asserted a <b>~13%
+     * random event</b> (the per-check technical probability is ~0.00175, so the fixture
+     * expected ~0.14 technicals), and it broke <b>twice</b> on passes that touched
+     * neither technicals nor fouls — §3.14b added a draw per foul, §3.17 changed what
+     * {@code pickShotType} returns — each time costing a re-baseline of the seed
+     * (7 → 9 → 12) that bought nothing but the next break.
      *
-     * <p>⚠ <b>THIS PRECONDITION IS INHERENTLY FRAGILE AND THE FRAGILITY IS WORTH KNOWING
-     * — it is asserting a ~13% EVENT, not an invariant.</b> The per-check technical
-     * probability is ~0.00175, so 40 possessions × 2 teams expects ~0.14 technicals; "at
-     * least one" happens on roughly one seed in eight. That is why it has now broken
-     * twice on passes that touched neither technicals nor fouls.
+     * <p>What replaces it: <b>assert the reconciliation identity over a BATCH of seeds
+     * and delete the precondition.</b> The identity {@code technicalEvents ==
+     * boxTechnicals} holds for <b>every</b> seed — including zero-technical ones, where
+     * it reads 0 == 0 and still proves the persisted column is not being written with
+     * garbage. So the batch is non-vacuous <b>by construction</b> and there is nothing
+     * left to re-pin: no future pass can break it by shifting the RNG stream, only by
+     * actually breaking the write. Ten seeds also all but guarantee some technicals
+     * appear somewhere in the batch, but nothing depends on that.
      *
-     * <p>⚠ <b>IT IS ALSO ORDER-DEPENDENT, WHICH IS A SEPARATE AND LARGER PROBLEM.</b>
-     * Measured 2026-08: this test <b>fails in isolation and passes in the full suite</b>
-     * on the same seed. {@code V1ApiDelegateimplTest} is not {@code @Transactional} and
-     * commits roster rows, which changes who is on the floor and therefore the RNG
-     * consumption pattern. <b>So a green full-suite run does NOT prove this test passes
-     * — CI caught what a local {@code mvn install} did not.</b> Filed as a backlog chore;
-     * the durable fix is to stop asserting a rare event in a fixed-seed test (raise the
-     * possession count, or assert the reconciliation identity over a batch of seeds and
-     * drop the precondition), not to keep re-pinning the seed.
+     * <p>The fixture is also back to the realistic <b>{@code 25} possessions per
+     * period</b> — the baseline {@code sim.default-possessions-per-period}, and what
+     * every other test in this class uses. The 40 existed only to make the coin flip a
+     * better bet; ⚠ it is possessions per PERIOD, not per game, so 40 was a ~60%
+     * inflation of game length, pushing the fixture away from a real game to prop up an
+     * assertion that has now been deleted.
+     *
+     * <p>⚠ <b>Rejected, do not revisit:</b> raising the possession count further (same
+     * coin flip, worse fixture) and re-pinning the seed (failed three times).
      */
     @Test
     void technicalFoulsArePersistedOnTheBoxScoreAndReconcileWithTheEvents() {
-        SimResult result = simulator.simulate("CHI", "NY", 12L, 40);
-        List<GameEventEntity> events = gameEventRepo
-                .findByGameIdOrderBySequenceAsc(result.getGameId());
-        List<BoxScoreEntity> boxScores = boxScoreRepo.findByGameId(result.getGameId());
+        // Ten seeds; the identity holds on each one independently, so a failure names
+        // the seed it failed on rather than reporting an aggregate that could hide a
+        // compensating pair.
+        for (long seed : new long[]{1L, 2L, 3L, 5L, 7L, 12L, 42L, 99L, 123L, 777L}) {
+            SimResult result = simulator.simulate("CHI", "NY", seed, 25);
+            List<GameEventEntity> events = gameEventRepo
+                    .findByGameIdOrderBySequenceAsc(result.getGameId());
+            List<BoxScoreEntity> boxScores = boxScoreRepo.findByGameId(result.getGameId());
 
-        long technicalEvents = events.stream()
-                .filter(e -> e.getPlayType() == PlayType.FOUL)
-                .filter(e -> GameData.TECHNICAL_FOUL_OUTCOME.equals(e.getOutcome()))
-                .count();
-        assertTrue(technicalEvents > 0,
-                "A 40-possession game must produce at least one technical");
+            long technicalEvents = events.stream()
+                    .filter(e -> e.getPlayType() == PlayType.FOUL)
+                    .filter(e -> GameData.TECHNICAL_FOUL_OUTCOME.equals(e.getOutcome()))
+                    .count();
 
-        int boxTechnicals = boxScores.stream()
-                .mapToInt(b -> b.getTechnicalFouls() == null ? 0 : b.getTechnicalFouls())
-                .sum();
-        assertEquals(technicalEvents, boxTechnicals,
-                "Persisted technicalFouls must reconcile with TECHNICAL_FOUL events");
+            int boxTechnicals = boxScores.stream()
+                    .mapToInt(b -> b.getTechnicalFouls() == null ? 0 : b.getTechnicalFouls())
+                    .sum();
+            assertEquals(technicalEvents, boxTechnicals,
+                    "Persisted technicalFouls must reconcile with TECHNICAL_FOUL events"
+                            + " (seed " + seed + ")");
 
-        // …and the two counters stay independent on the persisted row, which is the
-        // whole point of #032 E: a technical must never have inflated `fouls`.
-        long personalFoulEvents = events.stream()
-                .filter(e -> e.getPlayType() == PlayType.FOUL)
-                .filter(e -> e.getPrimaryPlayerId() != null)
-                .filter(e -> !GameData.TECHNICAL_FOUL_OUTCOME.equals(e.getOutcome()))
-                .count();
-        int boxFouls = boxScores.stream()
-                .mapToInt(b -> b.getFouls() == null ? 0 : b.getFouls()).sum();
-        assertEquals(personalFoulEvents, boxFouls);
+            // …and the two counters stay independent on the persisted row, which is the
+            // whole point of #032 E: a technical must never have inflated `fouls`.
+            long personalFoulEvents = events.stream()
+                    .filter(e -> e.getPlayType() == PlayType.FOUL)
+                    .filter(e -> e.getPrimaryPlayerId() != null)
+                    .filter(e -> !GameData.TECHNICAL_FOUL_OUTCOME.equals(e.getOutcome()))
+                    .count();
+            int boxFouls = boxScores.stream()
+                    .mapToInt(b -> b.getFouls() == null ? 0 : b.getFouls()).sum();
+            assertEquals(personalFoulEvents, boxFouls, "seed " + seed);
+        }
     }
 
 


### PR DESCRIPTION
…trustworthy

Three test-side tasks, no #NNN: the phase resolved no design question, and all three landed as planned. Defining property held — it moves NO engine number, proven by a same-seed harness run before/after (and again against a stashed tree): identical line for line across all 150 report lines, the only difference being the two new reconciliation lines themselves.

1. Finish harness self-verification. Two checks join the existing Agg.reconciliationMismatches mechanism as their own named counters, so a failure says WHICH instrument broke:
   - Reconciliation (ft-src): per-source FT counts sum to total FREE_THROW events AND the UNKNOWN bucket is empty. Both conditions — a sum-only check would pass with every FT tagged UNKNOWN, the exact failure it exists to catch. The sources are read off an outcome suffix, so a mis-tag silently distorts the FT-source percentages §3.20 reads.
   - Reconciliation (points): 2/3 per made SHOT + 1 per made FREE_THROW from the event log = box-score total = final score, all three. agg.points is read off the score while every other row derives from events, and nothing verified they agreed. Points is a headline §3.20 target.

2. Fix the brittle technicals test. It asserted a ~13% random event on a pinned seed (assertTrue(technicals > 0)) and broke twice on passes that touched neither technicals nor fouls, costing three seed re-baselines (7 -> 9 -> 12). Now asserts technicalEvents == boxTechnicals over ten seeds at the realistic 25 possessions/period, precondition deleted. The identity holds on every seed including zero-technical ones, so the batch is non-vacuous by construction and no future RNG shift can break it. Audited every other fixed-seed sim assertion for siblings: none — the remaining preconditions ride fouls (~18/game), shooting fouls (~6.5/team/game) and and-1s (~1.6/team/game), no coin flips.

3. @Transactional on V1ApiDelegateimplTest. It committed roster rows, changing who is on the floor and therefore RNG consumption downstream — how §3.17 shipped a red branch after two clean local builds. No method failed, so no latent coupling surfaced and the sim tests keep their shared fixture.

Verified: mvn clean install green (576 + 52 tests, JaCoCo gate met); sim classes green run ALONE, which task 3 makes equivalent to the full suite.

Docs: 5-seed mean (seeds 1000-5000, Profiles: local,baseline confirmed on each, all three reconciliation lines OK on all five) recorded in calibration.md's Current column — §3.20's input. Rows that moved against the previous reading were STALE, not new (4/5/6 fouls 0.94/0.46/0.30, and-1s 1.55, fouls/period 4.58, OOB 3.1, ejections 0.033); the pre-change run gives the same values. Roadmap §3.19 flipped to [x] with its landing note. todo.md rewritten for §3.20's design pass — its questions stay parked in roadmap.md's §3.20 bullet by design, so they survive the rewrite. Corrected four stale "§3.19 = recalibration" pointers in decisions.md's handoff INDEX (not any #NNN body) now that §3.19 names a shipped phase, and closed the PROB_FLOOR/blocks row as sized-and-closed rather than a Step 0 prerequisite. Removed two completed backlog chores (harness self-verification; the ~13%-random-event/order-dependence entry) per the remove-don't-check-off convention. Deleted CLAUDE.md's "until §3.19 lands" warning per its own instruction, keeping the run-sim-tests-alone habit as a cheap check.